### PR TITLE
add extractArchive bool parameter:

### DIFF
--- a/src/ios/ContentSync.m
+++ b/src/ios/ContentSync.m
@@ -38,7 +38,7 @@
 
     NSString* type = [command argumentAtIndex:2];
     BOOL local = [type isEqualToString:@"local"];
-    BOOL extractArchive = YES
+    BOOL extractArchive = YES;
 
     // if local mode, check file existence before download
     // we check the existence of file defined via option.id in the "Library" folder

--- a/www/index.js
+++ b/www/index.js
@@ -67,7 +67,7 @@ var ContentSync = function(options) {
     if (typeof options.copyRootApp === 'undefined') {
         options.copyRootApp = false;
     }
-    
+
     if (typeof options.timeout === 'undefined') {
         options.timeout = 15.0;
     }


### PR DESCRIPTION
This is allows to sync non-zip files too :

 - make it possible de specify non-zip files in sync method
 - backup the destination file in the specified location

(iOS only)

ex:

```js
var sync = ContentSync.sync({
    src: 'http://path/to/video.mp4',
    // unique name
    id: 'episode/42/video.mp4',
    // cachable
    type: 'local',
    // Not a zip
    extractArchive: false
});
```
Some remarks/questions :

 - why not using hash objects to pass parameters from plugin JS api to the native APIs, instead of long list of parameters ? (is there any cordova plugin boilerplate using this?)
 - the `copyRootApp` and `copyCordovaAssets` should imho be a separate method for this plugin, for example : `ContentSync.copyRootApp(destination)`