### PR TITLE
iOS still doing backup to iCloud

### DIFF
--- a/src/ios/ContentSync.m
+++ b/src/ios/ContentSync.m
@@ -444,7 +444,7 @@
         // END
 
         // Do not BACK UP folder to iCloud
-        NSURL* appURL = [NSURL fileURLWithPath: path];
+        NSURL* appURL = [NSURL fileURLWithPath: unzippedPath];
         NSError* error = nil;
         BOOL success = [appURL setResourceValue: [NSNumber numberWithBool: YES]
                                           forKey: NSURLIsExcludedFromBackupKey error: &error];

--- a/src/wp8/Sync.cs
+++ b/src/wp8/Sync.cs
@@ -646,8 +646,8 @@ namespace WPCordovaClassLib.Cordova.Commands
 
         private void copyCordovaAssets(string destFilePath)
         {
-            copyCordovaPlugins("x-wmapp0:www/cordova.js", destFilePath + "/www/cordova.js");
-            copyCordovaPlugins("x-wmapp0:www/cordova_plugins.js", destFilePath + "/www/cordova_plugins.js");
+            copyCordovaPlugins("x-wmapp0:www/cordova.js", destFilePath + "/cordova.js");
+            copyCordovaPlugins("x-wmapp0:www/cordova_plugins.js", destFilePath + "/cordova_plugins.js");
 
             Uri uri = new Uri("x-wmapp0:www/cordova_plugins.js", UriKind.RelativeOrAbsolute);
             Uri relUri = new Uri(uri.AbsolutePath, UriKind.Relative);
@@ -673,7 +673,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                 for(var i=0;i<pluginsJSON.Length;i++)
                 {
                     //Debug.WriteLine("x-wmapp0:www/" + pluginsJSON[i].file + " to " + destFilePath + "/" + pluginsJSON[i].file);
-                    copyCordovaPlugins("x-wmapp0:www/" + pluginsJSON[i].file, destFilePath + "/www/" + pluginsJSON[i].file);
+                    copyCordovaPlugins("x-wmapp0:www/" + pluginsJSON[i].file, destFilePath + "/" + pluginsJSON[i].file);
                 }
             }
         }


### PR DESCRIPTION
Looking at [Issue #40 and Issue #44 no backup to iCloud and remove files/ prefix](https://github.com/phonegap/phonegap-plugin-contentsync/commit/5b99bb162c556c37310184dc88427e77ec3ae090)
we can see that there is an implementation to not backup to iCloud. But while I was testing my application for submission to Apple Store I realize that it's still got my extracted folder to iCloud.
So, I changed it to use the `unzippedPath` instead of the `path`.


Just for you to know, I'm using the follow configuration for ContentSync:

```js
var sync = ContentSync.sync({ src: metadata.url, id: 'GVM', copyCordovaAssets: true });
```

I'm not sure if this is the correct way to do this. Should I mark either the path and the `unzippedPath` with the attribute? or Just the `unzippedPath` is ok?


