### PR TITLE
iOS still doing backup to iCloud

### DIFF
--- a/src/ios/ContentSync.m
+++ b/src/ios/ContentSync.m
@@ -444,13 +444,8 @@
         // END
 
         // Do not BACK UP folder to iCloud
-        NSURL* appURL = [NSURL fileURLWithPath: unzippedPath];
-        NSError* error = nil;
-        BOOL success = [appURL setResourceValue: [NSNumber numberWithBool: YES]
-                                          forKey: NSURLIsExcludedFromBackupKey error: &error];
-        if(!success) {
-            NSLog(@"Error excluding %@ from backup %@", [appURL lastPathComponent], error);
-        }
+        [self addSkipBackupAttributeToItemAtPath:path];
+        [self addSkipBackupAttributeToItemAtPath:unzippedPath];
 
         NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:2];
         [message setObject:unzippedPath forKey:@"localPath"];
@@ -460,6 +455,17 @@
         [self.commandDelegate sendPluginResult:pluginResult callbackId:sTask.command.callbackId];
         [[self syncTasks] removeObject:sTask];
     }
+}
+
+- (BOOL)addSkipBackupAttributeToItemAtPath:(NSString *)path {
+    NSURL* appURL = [NSURL fileURLWithPath: path];
+    NSError *error = nil;
+    BOOL success = [appURL setResourceValue: [NSNumber numberWithBool: YES]
+                              forKey: NSURLIsExcludedFromBackupKey error: &error];
+    if(!success){
+        NSLog(@"Error excluding %@ from backup %@", [appURL lastPathComponent], error);
+    }
+    return success;
 }
 
 - (BOOL) copyCordovaAssets:(NSString*)unzippedPath {

--- a/src/ios/ContentSync.m
+++ b/src/ios/ContentSync.m
@@ -444,7 +444,7 @@
         // END
 
         // Do not BACK UP folder to iCloud
-        NSURL* appURL = [NSURL fileURLWithPath: path];
+        NSURL* appURL = [NSURL fileURLWithPath: unzippedPath];
         NSError* error = nil;
         BOOL success = [appURL setResourceValue: [NSNumber numberWithBool: YES]
                                           forKey: NSURLIsExcludedFromBackupKey error: &error];


### PR DESCRIPTION
Looking at [Issue #40 and Issue #44 no backup to iCloud and remove files/ prefix](https://github.com/phonegap/phonegap-plugin-contentsync/commit/5b99bb162c556c37310184dc88427e77ec3ae090)
we can see that there is an implementation to not backup to iCloud. But while I was testing my application for submission to Apple Store I realize that it's still got my extracted folder to iCloud.
So, I changed it to use the `unzippedPath` instead of the `path`.


Just for you to know, I'm using the follow configuration for ContentSync:

```js
var sync = ContentSync.sync({ src: metadata.url, id: 'GVM', copyCordovaAssets: true });
```

I'm not sure if this is the correct way to do this. Should I mark either the path and the `unzippedPath` with the attribute? or Just the `unzippedPath` is ok?