### PR TITLE
issue-96 starting the same task multiple times should be prohibited

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Parameter | Description
 `options.headers` | `Object` _(Optional)_ Set of headers to use when requesting the remote content from `options.src`.
 `options.copyCordovaAssets` | `Boolean` _(Optional)_ Copies `cordova.js`, `cordova_plugins.js` and `plugins/` to sync'd folder. This operation happens after the source content has been cached, so it will override any existing Cordova assets. Default is `false`.
 `options.copyRootApp` | `Boolean` _(Optional)_ Copies the `www` folder to sync'd folder. This operation happens before the source content has been cached, then the source content is cached and finally it copies `cordova.js`, `cordova_plugins.js` and `plugins/` to sync'd folder to remain consistent with the installed plugins. Default is `false`.
-`options.timeout` | `Double` _(Optional)_ Request timeout. 
+`options.timeout` | `Double` _(Optional)_ Request timeout.
 `options.trustHost` | `Boolean` _(Optional)_ Trust SSL host. Host defined in `options.src` will be trusted. Ignored if `options.src` is undefined.
 `options.manifest` | `String` _(Optional)_ If specified the `copyRootApp` functionality will use the list of files contained in the manifest file during it's initial copy. {Android only}
 
@@ -120,7 +120,7 @@ The event `error` will trigger when an internal error occurs and the cache is ab
 
 Callback Parameter | Description
 ------------------ | -----------
-`e` | `Integer` Enumeration of `ERROR_STATE` to describe the current error 
+`e` | `Integer` Enumeration of `ERROR_STATE` to describe the current error
 
 #### Example
 
@@ -182,6 +182,8 @@ Error Code | Description
 `1` | `INVALID_URL_ERR`
 `2` | `CONNECTION_ERR`
 `3` | `UNZIP_ERR`
+`4` | `LOCAL_ERR`
+`5` | `IN_PROGRESS_ERR`
 
 ### ContentSync.unzip || Zip.unzip - ContentSync.download
 
@@ -223,7 +225,7 @@ sync.on('complete', function(data) {
     	// entry is a DirectoryEntry object
     }, function(error) {
         console.log("Error: " + error.code);
-    }); 
+    });
 });
 ```
 
@@ -251,7 +253,7 @@ The asset file system is pretty slow on Android so in order to speed up the init
 and if the file is placed in your apps `www` folder you would invoke it via:
 
 ```javascript
-var sync = ContentSync.sync({ src: 'http://myserver/assets/movie-1', id: 'movie-1', 
+var sync = ContentSync.sync({ src: 'http://myserver/assets/movie-1', id: 'movie-1',
         copyRootApp: true, manifest: 'manifest.json' });
 ```
 
@@ -271,7 +273,7 @@ This results in the `copyRootApp` taking about a third of the time as when a man
 npm test
 ```
 
-## Emulator Testing 
+## Emulator Testing
 
 The emulator tests use cordova-paramedic and the cordova-plugin-test-framework.
 To run them you will need cordova-paramedic installed.

--- a/src/ios/ContentSync.h
+++ b/src/ios/ContentSync.h
@@ -15,6 +15,7 @@ enum ErrorCodes {
     CONNECTION_ERR,
     UNZIP_ERR,
     LOCAL_ERR,
+    IN_PROGRESS_ERR,
 };
 typedef NSUInteger ErrorCodes;
 
@@ -31,9 +32,6 @@ typedef NSUInteger ErrorCodes;
 
 @interface ContentSync : CDVPlugin <NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDownloadDelegate, SSZipArchiveDelegate>
 
-@property (nonatomic) NSString* currentPath;
-@property (nonatomic) NSMutableArray *syncTasks;
-@property (nonatomic) NSURLSession* session;
 @property (nonatomic) NSMutableArray* trustedHosts;
 
 - (void) sync:(CDVInvokedUrlCommand*)command;

--- a/src/ios/SSZipArchive.h
+++ b/src/ios/SSZipArchive.h
@@ -46,7 +46,7 @@
 - (void)zipArchiveWillUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info)fileInfo;
 - (void)zipArchiveDidUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info)fileInfo;
 
-- (void)zipArchiveProgressEvent:(NSInteger)loaded total:(NSInteger)total;
+- (void)zipArchiveProgressEvent:(NSInteger)loaded total:(NSInteger)total archivePath:(NSString *)archivePath;
 @end
 
 #endif /* _SSZIPARCHIVE_H */

--- a/src/ios/SSZipArchive.m
+++ b/src/ios/SSZipArchive.m
@@ -81,8 +81,8 @@
 	if ([delegate respondsToSelector:@selector(zipArchiveWillUnzipArchiveAtPath:zipInfo:)]) {
 		[delegate zipArchiveWillUnzipArchiveAtPath:path zipInfo:globalInfo];
 	}
-	if ([delegate respondsToSelector:@selector(zipArchiveProgressEvent:total:)]) {
-		[delegate zipArchiveProgressEvent:(NSInteger)currentPosition total:(NSInteger)fileSize];
+	if ([delegate respondsToSelector:@selector(zipArchiveProgressEvent:total:archivePath:)]) {
+		[delegate zipArchiveProgressEvent:(NSInteger)currentPosition total:(NSInteger)fileSize archivePath:path];
 	}
 
 	NSInteger currentFileNumber = 0;
@@ -117,8 +117,8 @@
 				[delegate zipArchiveWillUnzipFileAtIndex:currentFileNumber totalFiles:(NSInteger)globalInfo.number_entry
 											 archivePath:path fileInfo:fileInfo];
 			}
-			if ([delegate respondsToSelector:@selector(zipArchiveProgressEvent:total:)]) {
-				[delegate zipArchiveProgressEvent:(NSInteger)currentPosition total:(NSInteger)fileSize];
+			if ([delegate respondsToSelector:@selector(zipArchiveProgressEvent:total:archivePath:)]) {
+				[delegate zipArchiveProgressEvent:(NSInteger)currentPosition total:(NSInteger)fileSize archivePath:path];
 			}
 
 			char *filename = (char *)malloc(fileInfo.size_filename + 1);
@@ -227,7 +227,7 @@
                             // Unable to set the permissions attribute
                             NSLog(@"[SSZipArchive] Failed to set attributes - whilst setting permissions");
                         }
-                        
+
 #if !__has_feature(objc_arc)
                         [attrs release];
 #endif
@@ -293,8 +293,8 @@
 		[delegate zipArchiveDidUnzipArchiveAtPath:path zipInfo:globalInfo unzippedPath:destination];
 	}
 	// final progress event = 100%
-	if ([delegate respondsToSelector:@selector(zipArchiveProgressEvent:total:)]) {
-		[delegate zipArchiveProgressEvent:(NSInteger)fileSize total:(NSInteger)fileSize];
+	if ([delegate respondsToSelector:@selector(zipArchiveProgressEvent:total:archivePath:)]) {
+		[delegate zipArchiveProgressEvent:(NSInteger)fileSize total:(NSInteger)fileSize archivePath:path];
 	}
 
 	return success;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -141,6 +141,39 @@ exports.defineAutoTests = function() {
             });
         });
 
+        it("syncing the same id concurrently should fail", function(done){
+
+            var url = "https://github.com/timkim/zipTest/archive/master.zip";
+            var sync1 = ContentSync.sync({ src: url, id: 'myapps/myapp', type: 'replace', copyCordovaAssets: false, headers: false });
+            var sync2 = ContentSync.sync({ src: url, id: 'myapps/myapp', type: 'replace', copyCordovaAssets: false, headers: false });
+
+            var numFinished = 0;
+
+            sync1.on('complete', function(data) {
+                expect(data).toBeDefined("On complete, data is not null");
+                if (++numFinished == 2) {
+                    done();
+                }
+            });
+            sync1.on('error', function(e) {
+                fail(e);
+                done();
+            });
+
+            sync2.on('complete', function(data) {
+                fail('syncing concurrently the same id should fail.');
+                done();
+            });
+            sync2.on('error', function(e) {
+                expect(e).toEqual(5);
+                if (++numFinished == 2) {
+                    done();
+                }
+            });
+
+        }, 60000); // wait a full 60 secs
+
+
     });
 
 

--- a/www/index.js
+++ b/www/index.js
@@ -261,6 +261,8 @@ module.exports = {
     ERROR_STATE: {
         1: 'INVALID_URL_ERR',
         2: 'CONNECTION_ERR',
-        3: 'UNZIP_ERR'
+        3: 'UNZIP_ERR',
+        4: 'LOCAL_ERR',
+        5: 'IN_PROGRESS_ERR'
     }
 };


### PR DESCRIPTION
- synchronize access to `syncTasks`
- don't export `syncTasks` and other internal variables
- reject adding the same task twice
- modify zip delegate to include archive path so that progress update doesn't need a thread-unsafe path

also fixes:
- issue-94 Exception in findSyncDataByDownloadTask
