### PR TITLE
Visual Studio treats a warning as an error

### DIFF
--- a/src/ios/ContentSync.m
+++ b/src/ios/ContentSync.m
@@ -342,7 +342,7 @@
 
         if(error == nil) {
             if([(NSHTTPURLResponse*)[task response] statusCode] != 200) {
-                NSLog(@"Task: %@ completed with HTTP Error Code: %ld", task, [(NSHTTPURLResponse*)[task response] statusCode]);
+                NSLog(@"Task: %@ completed with HTTP Error Code: %ld", task, [(NSHTTPURLResponse*)[task response] (long)statusCode]);
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsInt:CONNECTION_ERR];
                 NSFileManager *fileManager = [NSFileManager defaultManager];
                 if([fileManager fileExistsAtPath:[sTask archivePath]]) {


### PR DESCRIPTION
Xcode generates a warning about inconsistent types (NSInteger and long, if I'm not mistaken). The code technically works as intended, but for some reason Visual Studio captures the warning as an error (even when I don't have that option active) and refuses to build.

The easy solution is, of course, to ad a cast to long to stop the warning.