### PR TITLE
Issue #142: [iOS] Incorrect MIME Types

### DIFF
--- a/src/ios/ContentSync.m
+++ b/src/ios/ContentSync.m
@@ -617,6 +617,10 @@
                              @"no-cache", @"Pragma",
                              [NSString stringWithFormat:@"%d", (int)[data length]], @"Content-Length",
                              nil];
+    NSMutableDictionary *headers = [NSMutableDictionary dictionaryWithDictionary:self.request.allHTTPHeaderFields];
+    headers[@"Cache-Control"] = @"no-cache";
+    headers[@"Cache-Control"] = @"Pragma";
+    headers[@"Content-Length"] = [NSString stringWithFormat:@"%d", (int)[data length]];
 
     // create a response using the request and our new HEADERs
     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.request.URL

--- a/src/ios/ContentSync.m
+++ b/src/ios/ContentSync.m
@@ -622,7 +622,7 @@
     // add the no-cache and MIME HEADERs to the request while preserving the existing HEADER values.
     NSMutableDictionary *headers = [NSMutableDictionary dictionaryWithDictionary:self.request.allHTTPHeaderFields];
     headers[@"Cache-Control"] = @"no-cache";
-    headers[@"Cache-Control"] = @"Pragma";
+    headers[@"Pragma"] = @"no-cache";
     headers[@"Content-Length"] = [NSString stringWithFormat:@"%d", (int)[data length]];
     headers[@"Content-Type"] = contentType;
 


### PR DESCRIPTION
Fixes #142 

Most files served from ContentSync's 'localPath' had a MIME Type of `application/octet-stream` under iOS 10. Surprisingly the only problematic effect I've seen from this so far is that svg graphics weren't drawing.

Also the anti-caching headers weren't being set if the existing `Accept` header was missing.