### PR TITLE
add option to inject 3-finger-tap home script

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Parameter | Description
 `options.timeout` | `Double` _(Optional)_ Request timeout. Default is 15 seconds.
 `options.trustHost` | `Boolean` _(Optional)_ Trust SSL host. Host defined in `options.src` will be trusted. Ignored if `options.src` is undefined.
 `options.manifest` | `String` _(Optional)_ If specified the `copyRootApp` functionality will use the list of files contained in the manifest file during it's initial copy. {Android only}
+`options.injectHomeScript | `Boolean` _(Optional)_ Enables three-finger-tap back functionality to get users back to the home screen from running apps.
 
 #### Returns
 

--- a/src/ios/ContentSync.m
+++ b/src/ios/ContentSync.m
@@ -465,6 +465,14 @@
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
         [pluginResult setKeepCallbackAsBool:NO];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:sTask.command.callbackId];
+
+        BOOL injectHomeScript = [[sTask.command argumentAtIndex:9 withDefault:@(NO)] boolValue];
+        
+        if (injectHomeScript == YES) {
+            [[NSNotificationCenter defaultCenter] removeObserver:self name:CDVPageDidLoadNotification object:nil];
+            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pageDidLoad:) name:CDVPageDidLoadNotification object:nil];
+        }
+        
         [[self syncTasks] removeObject:sTask];
     }
 }
@@ -558,6 +566,13 @@
         session = [NSURLSession sessionWithConfiguration:configuration delegate:self delegateQueue:nil];
     });
     return session;
+}
+
+- (void) pageDidLoad:(NSNotification *) notification
+{
+    // Michael Brooks' homepage.js (https://github.com/phonegap/connect-phonegap/blob/master/res/middleware/homepage.js)
+    NSString* tapScript = @"javascript: console.log('adding homepage.js'); (function(){var e={},t={touchstart:'touchstart',touchend:'touchend'};if(window.navigator.msPointerEnabled){t={touchstart:'MSPointerDown',touchend:'MSPointerUp'}}document.addEventListener(t.touchstart,function(t){var n=t.touches||[t],r;for(var i=0,s=n.length;i<s;i++){r=n[i];e[r.identifier||r.pointerId]=r}},false);document.addEventListener(t.touchend,function(t){var n=Object.keys(e).length;e={};if(n===3){t.preventDefault();window.history.back(window.history.length)}},false)})(window)";
+    [self.commandDelegate evalJs:tapScript];
 }
 
 @end

--- a/www/index.js
+++ b/www/index.js
@@ -80,6 +80,10 @@ var ContentSync = function(options) {
         options.manifest = "";
     }
 
+    if (typeof options.injectHomeScript === 'undefined') {
+        options.injectHomeScript = false;
+    }
+
     // store the options to this object instance
     this.options = options;
 
@@ -101,7 +105,7 @@ var ContentSync = function(options) {
 
     // wait at least one process tick to allow event subscriptions
     setTimeout(function() {
-        exec(success, fail, 'Sync', 'sync', [options.src, options.id, options.type, options.headers, options.copyCordovaAssets, options.copyRootApp, options.timeout, options.trustHost, options.manifest]);
+        exec(success, fail, 'Sync', 'sync', [options.src, options.id, options.type, options.headers, options.copyCordovaAssets, options.copyRootApp, options.timeout, options.trustHost, options.manifest, options.injectHomeScript]);
     }, 10);
 };
 


### PR DESCRIPTION
The phonegap developer app injects it on the server side, but for the use case when the synced assets are static files, we'd like to inject the home script on the client side.

TODO:
- other platforms (iOS only so far)
- specs