### PR TITLE
Introducing Backward-Compatible Cocoapods Support.

### DIFF
--- a/src/ios/ContentSync.h
+++ b/src/ios/ContentSync.h
@@ -19,7 +19,12 @@
 #import <Foundation/Foundation.h>
 #import <Cordova/CDVPlugin.h>
 #import <Cordova/CDVAvailability.h>
+
+#ifdef USE_COCOAPODS
+#import <SSZipArchive/SSZipArchive.h>
+#else
 #import "SSZipArchive.h"
+#endif
 
 enum ProgressState {
     Stopped = 0,

--- a/src/ios/ContentSync.h
+++ b/src/ios/ContentSync.h
@@ -20,12 +20,6 @@
 #import <Cordova/CDVPlugin.h>
 #import <Cordova/CDVAvailability.h>
 
-#ifdef USE_COCOAPODS
-#import <SSZipArchive/SSZipArchive.h>
-#else
-#import "SSZipArchive.h"
-#endif
-
 enum ProgressState {
     Stopped = 0,
     Downloading,
@@ -56,7 +50,7 @@ typedef NSUInteger ErrorCodes;
 
 @end
 
-@interface ContentSync : CDVPlugin <NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDownloadDelegate, SSZipArchiveDelegate>
+@interface ContentSync : CDVPlugin <NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDownloadDelegate>
 
 @property (nonatomic) NSString* currentPath;
 @property (nonatomic) NSMutableArray *syncTasks;

--- a/src/ios/ContentSync.m
+++ b/src/ios/ContentSync.m
@@ -211,7 +211,7 @@
 
     if(srcURL && srcURL.scheme && srcURL.host && error == nil && response.statusCode < 400) {
 
-        BOOL trustHost = [command argumentAtIndex:7 withDefault:@(NO)];
+        BOOL trustHost = (BOOL) [command argumentAtIndex:7 withDefault:@(NO)];
 
         if(!self.trustedHosts) {
             self.trustedHosts = [NSMutableArray arrayWithCapacity:1];
@@ -527,7 +527,7 @@
     self.currentPath = path;
 }
 
-- (void) zipArchiveProgressEvent:(NSInteger)loaded total:(NSInteger)total {
+- (void)zipArchiveProgressEvent:(unsigned long long)loaded total:(unsigned long long)total {
     ContentSyncTask* sTask = [self findSyncDataByPath];
     if(sTask) {
         //NSLog(@"Extracting %ld / %ld", (long)loaded, (long)total);
@@ -658,7 +658,10 @@
         }
         else
         {
+            #pragma clang diagnostic push
+            #pragma clang diagnostic ignored "-Wdeprecated-declarations"
             configuration = [NSURLSessionConfiguration backgroundSessionConfiguration:sessionId];
+            #pragma clang diagnostic pop
         }
 #else
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_0

--- a/src/ios/ContentSync.m
+++ b/src/ios/ContentSync.m
@@ -21,6 +21,12 @@
 #import <MobileCoreServices/MobileCoreServices.h>
 #endif
 
+#ifdef USE_COCOAPODS
+#import <SSZipArchive/SSZipArchive.h>
+#else
+#import "SSZipArchive.h"
+#endif
+
 @implementation ContentSyncTask
 
 - (ContentSyncTask *)init {
@@ -36,6 +42,9 @@
 
     return self;
 }
+@end
+
+@interface ContentSync () <SSZipArchiveDelegate>
 @end
 
 @implementation ContentSync


### PR DESCRIPTION
I published a [.podspec](https://github.com/CocoaPods/Specs/blob/master/Specs/phonegap-plugin-contentsync/1.2.5.cocoapods/phonegap-plugin-contentsync.podspec.json) called `phonegap-plugin-contentsync` versioned `1.2.5.cocoapods`. I versioned it that because I had forked from `1.2.4`. I have since rebased for this pull request. I took the information I included in the `.podspec` from this repository.

The `.podspec` references my fork as I needed to make changes to `ContentSync.*`. The changes made were minimal. They fixed some warnings that came up with `xcodebuild`, and made the `#import`ing of `SSZipArchive` conditional depending on if you are using dependency management or the already embedded version.

I briefly tested the fork using the following. I imagine it would not have built here if `SSZipArchive` couldn't be linked properly.
```bash
$ phonegap plugin add https://github.com/ttahmouch/phonegap-plugin-contentsync
$ phonegap run ios
```

I also briefly tested using the `.podspec` as a dependency in an example `Podfile` shown below.
```ruby
platform :ios, '9.0'

pod 'Cordova', '4.2.1'
pod 'phonegap-plugin-contentsync', '1.2.5.cocoapods'

target 'ContentSyncApplication' do
  # Uncomment this line if you're using Swift or would like to use dynamic frameworks
  # use_frameworks!

  # Pods for ContentSyncApplication

  target 'ContentSyncApplicationTests' do
    inherit! :search_paths
    # Pods for testing
  end

  target 'ContentSyncApplicationUITests' do
    inherit! :search_paths
    # Pods for testing
  end

end
```

The `.podspec` only acknowledges `src/ios/ContentSync.{h,m}` as source code as `SSZipArchive` is now a **Cocoapods** dependency, i.e., it ignores `minizip/` and `SSZipArchive.*` when the source is fetched. However, it preserves the paths of `*.md` and `www/*.js` similarly to already existing `cordova-plugin-*` **Cocoapods**. This helps with retaining the `README` and companion **Javascript** to be invoked from a `CDVViewController`.

The `.podspec` also includes an **Xcode** configuration of `"OTHER_CFLAGS": "-DUSE_COCOAPODS=1"` to conditionally change the way `SSZipArchive` is imported if you are using **Cocoapods**.