### PR TITLE
Avoid crash (NullPointerException)  on Android if dir.list() return null

### DIFF
--- a/src/android/Sync.java
+++ b/src/android/Sync.java
@@ -517,10 +517,9 @@ public class Sync extends CordovaPlugin {
                     JSONObject result = new JSONObject();
                     result.put(PROP_LOCAL_PATH, outputDirectory);
 
-                    Log.d(LOG_TAG, "size of output dir = " + dir.list().length);
                     boolean cached = false;
-                    if (type.equals(TYPE_LOCAL) && dir.exists() && dir.isDirectory() && dir.list().length > 0) {
-                        Log.d(LOG_TAG, "we have a dir with some files in it.");
+                    if (type.equals(TYPE_LOCAL) && dir.exists() && dir.isDirectory() && dir.list() != null && dir.list().length > 0) {
+                        Log.d(LOG_TAG, "we have a dir with " + dir.list().length + " files in it.");
                         cached = true;
                     }
 


### PR DESCRIPTION
"dir.list().length", in the Log.d, at line 520 may cause "NullPointerException" as the list method returns either an array of string or null.

DOC: https://developer.android.com/reference/java/io/File.html#list()

LOGS : 
FATAL EXCEPTION: pool-1-thread-2
Process: com.fullspark.nhhp, PID: 2746
java.lang.NullPointerException: Attempt to get length of null array at com.adobe.phonegap.contentsync.Sync$4.run(Sync.java:520) at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113) at java.util.concurrent.ThreadPoolExecuto at java.lang.Thread.run(Thread.java:818)