### PR TITLE
Fix Windows unarchiving memory issues

### DIFF
--- a/src/windows/ZipWinProj/PGZipInflate.cs
+++ b/src/windows/ZipWinProj/PGZipInflate.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
@@ -44,19 +44,15 @@ namespace ZipWinProj
                 // Read uncompressed contents 
                 using (Stream entryStream = entry.Open())
                 {
-                    byte[] buffer = new byte[entry.Length];
-                    entryStream.Read(buffer, 0, buffer.Length);
-
-                    // Create a file to store the contents 
+                    // Create a file to store the contents
                     StorageFile uncompressedFile = await destFolder.CreateFileAsync(entry.Name, CreationCollisionOption.ReplaceExisting);
 
-                    // Store the contents 
-                    using (IRandomAccessStream uncompressedFileStream = 
+                    using (IRandomAccessStream uncompressedFileStream =
                         await uncompressedFile.OpenAsync(FileAccessMode.ReadWrite))
                     {
                         using (Stream outstream = uncompressedFileStream.AsStreamForWrite())
                         {
-                            outstream.Write(buffer, 0, buffer.Length);
+                            await entryStream.CopyToAsync(outstream);
                             outstream.Flush();
                         }
                     }


### PR DESCRIPTION
The current version of the plugin for Windows uses an unzip technique that requires copying each entire file in the zip archive into memory, before writing the file to disk. This works fine on small files, but causes the application to crash with an `Out of Memory` exception on larger files.

Since all the Windows file reading and writing uses streams, the change in this pull request removes the unnecessary reading of the file stream into a memory buffer and instead directly pipes the zip entry file to the output stream using `CopyToAsync` letting Windows handle the copy.  This also has the benefit of being asynchronous, removes the memory loading step, and is simpler code overall.

I've successfully copied gigabyte files with almost no memory impact. I've tested this under Windows 10 only, however [MSDN lists](https://msdn.microsoft.com/en-us/library/hh159084(v=vs.110).aspx) `CopyToAsync` as being available since Windows Phone 8.1 and Universal Windows Platform 8.