### PR TITLE
Only copyRootApp when app version has been updated

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="phonegap-plugin-contentsync" version="1.3.3">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="phonegap-plugin-contentsync" version="1.3.4">
   <name>content-sync</name>
   <description>PhoneGap Content Sync Plugin</description>
   <license/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,6 +20,7 @@
         <param name="android-package" value="com.adobe.phonegap.contentsync.Sync"/>
       </feature>
     </config-file>
+    <framework src="com.android.support:support-v4:23+"/>
     <source-file src="src/android/Sync.java" target-dir="src/com/adobe/phonegap/contentsync"/>
   </platform>
   <platform name="browser">

--- a/src/android/Sync.java
+++ b/src/android/Sync.java
@@ -63,6 +63,7 @@ import android.content.res.AssetManager;
 import android.net.Uri;
 import android.os.Environment;
 import android.os.StatFs;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import android.util.Patterns;
 import android.webkit.CookieManager;
@@ -431,6 +432,7 @@ public class Sync extends CordovaPlugin {
             copyCordovaAssets = args.getBoolean(4);
         }
         final String manifestFile = args.getString(8);
+        final boolean backup = args.getBoolean(10);
         Log.d(LOG_TAG, "sync called with id = " + id + " and src = " + src + "!");
 
         final ProgressEvent progress = createProgressEvent(id);
@@ -453,7 +455,7 @@ public class Sync extends CordovaPlugin {
                     }
                 }
 
-                String outputDirectory = getOutputDirectory(id);
+                String outputDirectory = getOutputDirectory(id, backup);
 
                 // Check to see if we should just return the cached version
                 String type = args.optString(2, TYPE_REPLACE);
@@ -607,9 +609,14 @@ public class Sync extends CordovaPlugin {
         return success;
     }
 
-    private String getOutputDirectory(final String id) {
+    private String getOutputDirectory(final String id, boolean backup) {
         // Production
-        String outputDirectory = cordova.getActivity().getFilesDir().getAbsolutePath();
+        String outputDirectory = null;
+        if (backup) {
+            outputDirectory = cordova.getActivity().getFilesDir().getAbsolutePath();
+        } else {
+            outputDirectory = ContextCompat.getNoBackupFilesDir(cordova.getActivity()).getAbsolutePath();
+        }
         // Testing
         //String outputDirectory = cordova.getActivity().getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS).getAbsolutePath();
         outputDirectory += outputDirectory.endsWith(File.separator) ? "" : File.separator;

--- a/src/ios/ContentSync.m
+++ b/src/ios/ContentSync.m
@@ -127,17 +127,19 @@
     NSString* src = [command argumentAtIndex:0 withDefault:nil];
     NSString* type = [command argumentAtIndex:2];
     BOOL local = [type isEqualToString:@"local"];
-    BOOL appUpdated = [ContentSync hasAppBeenUpdated];
 
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSString* appId = [command argumentAtIndex:1];
     NSURL* storageDirectory = [ContentSync getStorageDirectory];
     NSURL *appPath = [storageDirectory URLByAppendingPathComponent:appId];
     NSLog(@"appPath %@", appPath);
+    
+    BOOL appUpdated = [ContentSync hasAppBeenUpdated];
+    BOOL cacheExists = [fileManager fileExistsAtPath:[appPath path]];
 
     if(local == YES) {
         NSLog(@"Requesting local copy of %@", appId);
-        if([fileManager fileExistsAtPath:[appPath path]] && !appUpdated) {
+        if(cacheExists && !appUpdated) {
             NSLog(@"Found local copy %@", [appPath path]);
             CDVPluginResult *pluginResult = nil;
 
@@ -174,7 +176,7 @@
             [message setObject:[NSNumber numberWithInteger:-1] forKey:@"responseCode"];
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:message];
             NSLog(@"%@", [error localizedDescription]);
-        } else if(appUpdated) {
+        } else if(!cacheExists || appUpdated) {
             [self copyCordovaAssets:[appPath path] copyRootApp:YES];
             if(src == nil) {
                 NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:2];

--- a/src/ios/ContentSync.m
+++ b/src/ios/ContentSync.m
@@ -127,6 +127,7 @@
     NSString* src = [command argumentAtIndex:0 withDefault:nil];
     NSString* type = [command argumentAtIndex:2];
     BOOL local = [type isEqualToString:@"local"];
+    BOOL appUpdated = [ContentSync hasAppBeenUpdated];
 
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSString* appId = [command argumentAtIndex:1];
@@ -136,19 +137,17 @@
 
     if(local == YES) {
         NSLog(@"Requesting local copy of %@", appId);
-        if([fileManager fileExistsAtPath:[appPath path]]) {
-            if (![ContentSync hasAppBeenUpdated]) {
-                NSLog(@"Found local copy %@", [appPath path]);
-                CDVPluginResult *pluginResult = nil;
+        if([fileManager fileExistsAtPath:[appPath path]] && !appUpdated) {
+            NSLog(@"Found local copy %@", [appPath path]);
+            CDVPluginResult *pluginResult = nil;
 
-                NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:2];
-                [message setObject:[appPath path] forKey:@"localPath"];
-                [message setObject:@"true" forKey:@"cached"];
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
+            NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:2];
+            [message setObject:[appPath path] forKey:@"localPath"];
+            [message setObject:@"true" forKey:@"cached"];
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
 
-                [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-                return;
-            }
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+            return;
         }
     }
 
@@ -175,7 +174,7 @@
             [message setObject:[NSNumber numberWithInteger:-1] forKey:@"responseCode"];
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:message];
             NSLog(@"%@", [error localizedDescription]);
-        } else {
+        } else if(appUpdated) {
             [self copyCordovaAssets:[appPath path] copyRootApp:YES];
             if(src == nil) {
                 NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:2];

--- a/src/ios/ContentSync.m
+++ b/src/ios/ContentSync.m
@@ -651,26 +651,78 @@
     return success;
 }
 
+- (void)mergeFolders:(NSString *)srcDir intoPath:(NSString *)dstDir error:(NSError**)err {
+
+    NSLog(@"- mergeFolders: %@\n intoPath: %@", srcDir, dstDir);
+
+    NSFileManager *fm = [NSFileManager defaultManager];
+    NSDirectoryEnumerator *srcDirEnum = [fm enumeratorAtPath:srcDir];
+    NSString *subPath;
+    while ((subPath = [srcDirEnum nextObject])) {
+        NSLog(@" subPath: %@", subPath);
+        NSString *srcFullPath =  [srcDir stringByAppendingPathComponent:subPath];
+        NSString *potentialDstPath = [dstDir stringByAppendingPathComponent:subPath];
+
+        // Need to also check if file exists because if it doesn't, value of `isDirectory` is undefined.
+        BOOL isDirectory = ([[NSFileManager defaultManager] fileExistsAtPath:srcFullPath isDirectory:&isDirectory] && isDirectory);
+
+        // Create directory, or delete existing file and move file to destination
+        if (isDirectory) {
+            NSLog(@"   create directory");
+            [fm createDirectoryAtPath:potentialDstPath withIntermediateDirectories:YES attributes:nil error:err];
+            if (err && *err) {
+                NSLog(@"ERROR: %@", *err);
+                return;
+            }
+        }
+        else {
+            if ([fm fileExistsAtPath:potentialDstPath]) {
+                NSLog(@"   removeItemAtPath");
+                [fm removeItemAtPath:potentialDstPath error:err];
+                if (err && *err) {
+                    NSLog(@"ERROR: %@", *err);
+                    return;
+                }
+            }
+
+            NSLog(@"   copyItemAtPath");
+            [fm copyItemAtPath:srcFullPath toPath:potentialDstPath error:err];
+            if (err && *err) {
+                NSLog(@"ERROR: %@", *err);
+                return;
+            }
+        }
+    }
+}
+
 - (BOOL) copyCordovaAssets:(NSString*)unzippedPath {
     return [self copyCordovaAssets:unzippedPath copyRootApp:false];
 }
 
 // TODO GET RID OF THIS
+// THIS F!@#% BS
 - (BOOL) copyCordovaAssets:(NSString*)unzippedPath copyRootApp:(BOOL)copyRootApp {
+    NSLog(@"copyCordovaAssets");
     NSError *errorCopy;
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSURL* destinationURL = [NSURL fileURLWithPath:unzippedPath];
 
     if(copyRootApp == YES) {
         NSLog(@"Copying Root App");
+        NSString* suffix = @"/www";
+        NSString* destDir = unzippedPath;
+
+        if([fileManager fileExistsAtPath:[unzippedPath stringByAppendingString:suffix]]) {
+            destDir = [unzippedPath stringByAppendingString:suffix];
+            NSLog(@"Found %@ folder. Will copy root application to it.", suffix);
+        }
         // we use cordova.js as a way to find the root www/
         NSString* root = [[[self commandDelegate] pathForResource:@"cordova.js"] stringByDeletingLastPathComponent];
 
-        NSURL* sourceURL = [NSURL fileURLWithPath:root];
-        [fileManager removeItemAtURL:destinationURL error:NULL];
-        BOOL success = [fileManager copyItemAtURL:sourceURL toURL:destinationURL error:&errorCopy];
-
-        if(!success) {
+        NSError *mergeError = nil;
+        [self mergeFolders:root intoPath:destDir error:&mergeError];
+        if(mergeError != nil) {
+            NSLog(@"An error occurred: %@", [mergeError localizedDescription]);
             return NO;
         }
 

--- a/www/index.js
+++ b/www/index.js
@@ -78,11 +78,15 @@ var ContentSync = function(options) {
     }
 
     if (typeof options.manifest === 'undefined') {
-        options.manifest = "";
+        options.manifest = '';
     }
 
     if (typeof options.validateSrc === 'undefined') {
         options.validateSrc = true;
+    }
+
+    if (typeof options.backup === 'undefined') {
+        options.backup = false;
     }
 
     // store the options to this object instance
@@ -106,7 +110,7 @@ var ContentSync = function(options) {
 
     // wait at least one process tick to allow event subscriptions
     setTimeout(function() {
-        exec(success, fail, 'Sync', 'sync', [options.src, options.id, options.type, options.headers, options.copyCordovaAssets, options.copyRootApp, options.timeout, options.trustHost, options.manifest, options.validateSrc]);
+        exec(success, fail, 'Sync', 'sync', [options.src, options.id, options.type, options.headers, options.copyCordovaAssets, options.copyRootApp, options.timeout, options.trustHost, options.manifest, options.validateSrc, options.backup]);
     }, 10);
 };
 
@@ -228,11 +232,11 @@ module.exports = {
         var callback = (typeof headers == "function" ? headers : cb);
         exec(callback, callback, 'Sync', 'download', [url, null, headers]);
     },
-    
+
     /**
      * loadUrl
      *
-     * This method allows loading file:// urls when using WKWebViews on iOS. 
+     * This method allows loading file:// urls when using WKWebViews on iOS.
      *
      */
 


### PR DESCRIPTION
This change might be a useful mitigation for issue #166. While a root copy from the binary will still obliterate the existing app data cache on iOS (a problem if the app downloads additional content that isn't included in the binary), this at least makes sure that will only happen when the binary has been updated (or is a fresh install), i.e. it prevents destructive root copy syncs from occurring unless necessary.