### PR TITLE
Issue #170 Fixing potential NullPointerException while removing folders on Android

### DIFF
--- a/src/android/Sync.java
+++ b/src/android/Sync.java
@@ -1120,8 +1120,11 @@ public class Sync extends CordovaPlugin {
 
     private void removeFolder(File directory) {
         if (directory.exists() && directory.isDirectory()) {
-            for (File file : directory.listFiles()) {
-                removeFolder(file);
+            File files = directory.listFiles();
+            if (files != null) {
+                for (File file : files) {
+                    removeFolder(file);
+                }
             }
         }
         directory.delete();


### PR DESCRIPTION
According to https://docs.oracle.com/javase/7/docs/api/java/io/File.html#listFiles(), `listFiles` can potentially return `null`. So we just add a quick test to avoid the NPE.