### PR TITLE
include phonegap.js in copyCordovaAssets

### DIFF
--- a/src/android/Sync.java
+++ b/src/android/Sync.java
@@ -694,6 +694,9 @@ public class Sync extends CordovaPlugin {
             // cordova.js
             this.copyAssetFile(outputDirectory, "www/cordova.js", wwwExists);
 
+            // phonegap.js
+            this.copyAssetFile(outputDirectory, "www/phonegap.js", wwwExists);
+
             // cordova_plugins.js
             this.copyAssetFile(outputDirectory, "www/cordova_plugins.js", wwwExists);
 

--- a/src/ios/ContentSync.m
+++ b/src/ios/ContentSync.m
@@ -676,7 +676,7 @@
         return YES;
     }
     NSLog(@"Copying Cordova Assets");
-    NSArray* cordovaAssets = [NSArray arrayWithObjects:@"cordova.js",@"cordova_plugins.js",@"plugins", nil];
+    NSArray* cordovaAssets = [NSArray arrayWithObjects:@"cordova.js",@"phonegap.js",@"cordova_plugins.js",@"plugins", nil];
     NSString* suffix = @"/www";
 
     if([fileManager fileExistsAtPath:[unzippedPath stringByAppendingString:suffix]]) {

--- a/src/windows/SyncProxy.js
+++ b/src/windows/SyncProxy.js
@@ -30,6 +30,7 @@ function copyCordovaAssetsAsync(wwwFolder, destWWWFolder) {
     .then(function (pluginsFolder) {
         return WinJS.Promise.join([recursiveCopyFolderAsync(pluginsFolder, destWWWFolder, null, false),
                                    copyAndReplaceFileFromPathAsync(wwwFolder.path + "\\cordova.js", destWWWFolder),
+                                   copyAndReplaceFileFromPathAsync(wwwFolder.path + "\\phonegap.js", destWWWFolder),
                                    copyAndReplaceFileFromPathAsync(wwwFolder.path + "\\cordova_plugins.js", destWWWFolder)]);
     });
 }

--- a/src/wp8/Sync.cs
+++ b/src/wp8/Sync.cs
@@ -647,6 +647,7 @@ namespace WPCordovaClassLib.Cordova.Commands
         private void copyCordovaAssets(string destFilePath)
         {
             copyCordovaPlugins("x-wmapp0:www/cordova.js", destFilePath + "/www/cordova.js");
+            copyCordovaPlugins("x-wmapp0:www/phonegap.js", destFilePath + "/www/phonegap.js");
             copyCordovaPlugins("x-wmapp0:www/cordova_plugins.js", destFilePath + "/www/cordova_plugins.js");
 
             Uri uri = new Uri("x-wmapp0:www/cordova_plugins.js", UriKind.RelativeOrAbsolute);


### PR DESCRIPTION
On Phonegap Build we support both phonegap.js and cordova.js. Would be great if contentsync's copyCordovaAssets also copied phonegap.js.