### PR TITLE
#186 - [iOS] copyRootApp runs a second time on the second launch of the application, overwriting updates

### DIFF
--- a/src/ios/ContentSync.m
+++ b/src/ios/ContentSync.m
@@ -115,12 +115,19 @@
     // set previous version to current version
     [defaults setObject:currentVersion forKey:@"PREVIOUS_VERSION"];
     [defaults synchronize];
+    
+    BOOL appHasBeenUpdated = ([currentVersion compare:previousVersion options:NSNumericSearch] == NSOrderedDescending);
 
-    if ([currentVersion compare:previousVersion options:NSNumericSearch] == NSOrderedDescending) {
-        NSLog(@"current version is newer than previous version");;
+    // This condition seems to occur on the 2nd run of the app, when the PREVIOUS_VERSION entry has not yet been set.
+    // In this case, appHasBeenUpdated will incorrectly be set to YES, even though the app has not actually been updated.
+    if (previousVersion == nil && currentVersion != nil) {
+        NSLog(@"previous version has not yet been set. skipping comparison");
+        appHasBeenUpdated = false;
+    } else if (appHasBeenUpdated == true) {
+        NSLog(@"current version is newer than previous version");
     }
 
-    return ([currentVersion compare:previousVersion options:NSNumericSearch] == NSOrderedDescending);
+    return appHasBeenUpdated;
 }
 
 - (void)sync:(CDVInvokedUrlCommand*)command {


### PR DESCRIPTION
## Description

This change is a proposed fix to the issue described in detail in #186. In this fix, when a previousVersion is `nil` and the currentVersion is set, the plugin will overwrite the `appHasBeenUpdated` bool to false so that the copyRootApp operation is not run again.

## Related Issue

#186 

## Motivation and Context

A customer has reported this issue.

## How Has This Been Tested?

I have tested this issue manually on iOS 11.1, 10.3, and 10.2.

## Screenshots (if appropriate):

n/a

## Types of changes

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
