### PR TITLE
#188 - [iOS] calling sync() with options.copyCordovaAssets set does not perform copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,14 +320,26 @@ npm test
 ## Emulator Testing
 
 The emulator tests use cordova-paramedic and the cordova-plugin-test-framework.
-To run them you will need cordova-paramedic installed.
+To run them you will need cordova-paramedic installed:
 
     npm install -g cordova-paramedic
-    // Then from the root of this repo
+
+Some of the tests require a simple HTTP server to host .zip payloads:
+
+    ./tests/scripts/start-server.sh
+
+Run the tests:
+
+    // From the root of this repo
     // test ios :
     cordova-paramedic --platform ios --plugin .
+
     // test android :
     cordova-paramedic --platform android --plugin .
+
+Once complete, the simple HTTP server can be stopped:
+
+    ./tests/scripts/stop-server.sh
 
 ## Contributing
 

--- a/src/ios/ContentSync.m
+++ b/src/ios/ContentSync.m
@@ -160,8 +160,9 @@
     }
 
     BOOL copyRootApp = [[command argumentAtIndex:5 withDefault:@(NO)] boolValue];
+    BOOL copyCordovaAssetsValue = [[command argumentAtIndex:4 withDefault:@(NO)] boolValue];
 
-    if(copyRootApp == YES) {
+    if(copyRootApp == YES || copyCordovaAssetsValue == YES) {
         __block NSError* error = nil;
 
         NSLog(@"Creating app directory %@", [appPath path]);
@@ -185,7 +186,7 @@
         } else {
             [self.commandDelegate runInBackground:^{
                 CDVPluginResult *pluginResult = nil;
-                [self copyCordovaAssets:[appPath path] copyRootApp:YES];
+                [self copyCordovaAssets:[appPath path] copyRootApp:copyRootApp];
                 if(src == nil) {
                     NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:2];
                     [message setObject:[appPath path] forKey:@"localPath"];
@@ -709,8 +710,6 @@
     return [self copyCordovaAssets:unzippedPath copyRootApp:false];
 }
 
-// TODO GET RID OF THIS
-// THIS F!@#% BS
 - (BOOL) copyCordovaAssets:(NSString*)unzippedPath copyRootApp:(BOOL)copyRootApp {
     NSLog(@"copyCordovaAssets");
     NSError *errorCopy;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -14,7 +14,6 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
         function syncArchive(url, done) {
             
             var progressEvent = null;
-            //var url = "https://github.com/timkim/zipTest/archive/master.zip";
             var sync = ContentSync.sync({ src: url, id: 'myapps/myapp', type: 'replace', copyCordovaAssets: false, headers: false });
 
 
@@ -43,7 +42,7 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 
             sync.on('error', function (e) {
                 expect(progressEvent).toBeDefined("Progress should have been received");
-                expect(e).toBe(null, "Error callback was called :: " + e);
+                expect(e).toBe(null, "Error callback was called :: " + JSON.stringify(e));
                 //console.log("got error back :: " + e);
                 done();
             });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -77,6 +77,24 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
             });
         }, 60000); // wait a full 60 secs for slow Android emulator
 
+        it('tests copyCordovaAssets works without copyRootApp', function(done) {
+            var appId = 'copyCordovaAssets' + (new Date().getTime());
+            var sync = ContentSync.sync({
+                id: appId,
+                copyCordovaAssets: true,
+                type: 'local'
+            });
+
+            sync.on('complete', function(data) {
+                // cordova.js should be available in the synced directory
+                testFileExists(appId + '/cordova.js', function success() {
+                    done();
+                }, function fail() {
+                    fail('cordova.js should exist in the synced directory.');
+                });
+            });
+        });
+
         /**
          * Helper function that tests if the file at the given path exists
          */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix and test case for #188.

## Related Issue
#188

## Motivation and Context
We need to be able to call `sync()` with `copyCordovaAssets` set, but without `copyRootApp`.

## How Has This Been Tested?
- cordova-paramedic test added (thanks @macdonst for the help getting it running!)

## Screenshots (if appropriate):
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
